### PR TITLE
feat: Add light and dark mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,28 +9,55 @@
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script>
     tailwind.config = {
+      darkMode: 'class',
       theme: {
         extend: {
           colors: {
-            'bg': '#0f172a',
-            'card': '#111827',
-            'text': '#f1f5f9',
-            'muted': '#94a3b8',
-            'accent': '#3b82f6',
-            'accent-hover': '#2563eb',
-            'danger': '#ef4444',
-            'danger-hover': '#dc2626',
-            'border': '#1e293b',
-            'border-light': '#334155',
+            'bg': 'var(--color-bg)',
+            'card': 'var(--color-card)',
+            'text': 'var(--color-text)',
+            'muted': 'var(--color-muted)',
+            'accent': 'var(--color-accent)',
+            'accent-hover': 'var(--color-accent-hover)',
+            'danger': 'var(--color-danger)',
+            'danger-hover': 'var(--color-danger-hover)',
+            'border': 'var(--color-border)',
+            'border-light': 'var(--color-border-light)',
           }
         }
       }
     }
   </script>
   <style>
+    :root {
+      --color-bg: #f1f5f9;
+      --color-card: #ffffff;
+      --color-text: #0f172a;
+      --color-muted: #64748b;
+      --color-accent: #2563eb;
+      --color-accent-hover: #1d4ed8;
+      --color-danger: #dc2626;
+      --color-danger-hover: #b91c1c;
+      --color-border: #e2e8f0;
+      --color-border-light: #f1f5f9;
+    }
+
+    .dark {
+      --color-bg: #0f172a;
+      --color-card: #1e293b;
+      --color-text: #f1f5f9;
+      --color-muted: #94a3b8;
+      --color-accent: #3b82f6;
+      --color-accent-hover: #2563eb;
+      --color-danger: #ef4444;
+      --color-danger-hover: #dc2626;
+      --color-border: #334155;
+      --color-border-light: #475569;
+    }
+
     body {
       font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, sans-serif;
-      background: linear-gradient(135deg, #0b1223 0%, #0f172a 50%, #0a0f1c 100%);
+      background-color: var(--color-bg);
       min-height: 100vh;
     }
     
@@ -42,7 +69,6 @@
     .animate-fade-in {
       animation: fadeIn 0.6s ease-out;
     }
-
   </style>
 </head>
 
@@ -57,7 +83,7 @@
       <section class="mb-6">
         <div class="flex gap-3 items-center md:flex-row flex-col">
           <input id="newTodo" type="text" placeholder="What needs to be done?" aria-label="New todo" 
-                 class="flex-1 px-4 py-3.5 rounded-xl border border-border-light bg-slate-900/80 text-text text-base transition-all duration-200 focus:outline-none focus:border-accent focus:ring-3 focus:ring-accent/10 placeholder:text-muted w-full" />
+                 class="flex-1 px-4 py-3.5 rounded-xl border border-border-light bg-card text-text text-base transition-all duration-200 focus:outline-none focus:border-accent focus:ring-3 focus:ring-accent/10 placeholder:text-muted w-full" />
           <button id="addBtn" aria-label="Add todo" 
                   class="px-5 py-3.5 rounded-xl bg-accent text-white font-semibold text-sm cursor-pointer transition-all duration-200 hover:bg-accent-hover hover:-translate-y-0.5 whitespace-nowrap md:w-auto w-full">Add Task</button>
         </div>
@@ -81,7 +107,7 @@
           <span id="count">0</span> tasks • <span id="storage"></span>
         </div>
         <div class="text-xs opacity-80">
-          <span class="kbd px-2 py-1 border border-border-light rounded text-xs text-muted bg-slate-900/50">Enter</span> to add •
+          <span class="kbd px-2 py-1 border border-border-light rounded text-xs text-muted bg-card">Enter</span> to add •
         </div>
       </footer>
 
@@ -90,6 +116,10 @@
           <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="exportBtn" title="Export as JSON">Export</button>
           <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="importBtn" title="Import from JSON">Import</button>
           <input type="file" id="fileInput" accept="application/json" hidden />
+          <button id="theme-toggle" class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" title="Toggle theme">
+            <svg id="theme-icon-light" class="w-5 h-5 hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1zm4 8a4 4 0 1 1-8 0 4 4 0 0 1 8 0zm-.464 4.95.707.707a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 0 0-1.414 1.414zm2.121-3.536a1 1 0 0 1-.707.293 1 1 0 0 1-.707-.293l-.707-.707a1 1 0 1 1 1.414-1.414l.707.707a1 1 0 0 1 0 1.414zM4.464 4.95a1 1 0 0 0-1.414 1.414l.707.707a1 1 0 0 0 1.414-1.414L4.464 4.95zM2 10a1 1 0 0 1-1-1 1 1 0 0 1 1-1h1a1 1 0 1 1 0 2H2zm9 7a1 1 0 0 1-1-1v-1a1 1 0 1 1 2 0v1a1 1 0 0 1-1 1zM4.222 15.778a1 1 0 0 0 1.414-1.414l-.707-.707a1 1 0 1 0-1.414 1.414l.707.707zm11.314-1.414a1 1 0 1 0-1.414-1.414l-.707.707a1 1 0 1 0 1.414 1.414l.707-.707z"></path></svg>
+            <svg id="theme-icon-dark" class="w-5 h-5 hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 0 1 6.707 2.707a8.001 8.001 0 1 0 10.586 10.586z"></path></svg>
+          </button>
         </div>
       </section>
     </div>
@@ -201,7 +231,7 @@
         // Inline editing
         $li.find('span').on('dblclick', function() {
           const $span = $(this);
-          const $input = $(`<input class="flex-1 px-3 py-2 rounded-lg border border-accent bg-slate-900/90 text-text text-base" value="${todo.title}">`);
+          const $input = $(`<input class="flex-1 px-3 py-2 rounded-lg border border-accent bg-card text-text text-base" value="${todo.title}">`);
           
           $span.replaceWith($input);
           $input.focus().select();
@@ -358,6 +388,38 @@
       updateStorageInfo();
       render();
     });
+
+    // --- Theme Switcher ------------------------------------------------------
+    (function() {
+      const LS_THEME_KEY = "theme.v1";
+      const $html = $("html");
+      const $toggle = $("#theme-toggle");
+      const $iconLight = $("#theme-icon-light");
+      const $iconDark = $("#theme-icon-dark");
+
+      function setTheme(theme) {
+        if (theme === 'dark') {
+          $html.addClass('dark');
+          $iconLight.removeClass('hidden');
+          $iconDark.addClass('hidden');
+        } else {
+          $html.removeClass('dark');
+          $iconDark.removeClass('hidden');
+          $iconLight.addClass('hidden');
+        }
+        localStorage.setItem(LS_THEME_KEY, theme);
+      }
+
+      $toggle.on('click', function() {
+        const isDark = $html.hasClass('dark');
+        setTheme(isDark ? 'light' : 'dark');
+      });
+
+      // Load initial theme
+      const savedTheme = localStorage.getItem(LS_THEME_KEY);
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      setTheme(savedTheme || (prefersDark ? 'dark' : 'light'));
+    })();
   </script>
 </body>
 


### PR DESCRIPTION
This commit introduces a theme switcher that allows users to toggle between light and dark modes.

- The theme preference is saved in `localStorage`.
- The application defaults to the user's system preference.
- The UI has been updated to support both themes.