### PR TITLE
feat: Add light and dark mode theme switcher

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,25 +12,57 @@
       theme: {
         extend: {
           colors: {
-            'bg': '#0f172a',
-            'card': '#111827',
-            'text': '#f1f5f9',
-            'muted': '#94a3b8',
-            'accent': '#3b82f6',
-            'accent-hover': '#2563eb',
-            'danger': '#ef4444',
-            'danger-hover': '#dc2626',
-            'border': '#1e293b',
-            'border-light': '#334155',
+            'bg': 'var(--bg)',
+            'card': 'var(--card)',
+            'text': 'var(--text)',
+            'muted': 'var(--muted)',
+            'accent': 'var(--accent)',
+            'accent-hover': 'var(--accent-hover)',
+            'danger': 'var(--danger)',
+            'danger-hover': 'var(--danger-hover)',
+            'border': 'var(--border)',
+            'border-light': 'var(--border-light)',
           }
         }
       }
     }
   </script>
   <style>
+    :root {
+      --bg: #0f172a;
+      --card: #111827;
+      --text: #f1f5f9;
+      --muted: #94a3b8;
+      --accent: #3b82f6;
+      --accent-hover: #2563eb;
+      --danger: #ef4444;
+      --danger-hover: #dc2626;
+      --border: #1e293b;
+      --border-light: #334155;
+      --gradient-start: #0b1223;
+      --gradient-mid: #0f172a;
+      --gradient-end: #0a0f1c;
+    }
+
+    .light {
+      --bg: #f8fafc;
+      --card: #ffffff;
+      --text: #020617;
+      --muted: #64748b;
+      --accent: #3b82f6;
+      --accent-hover: #2563eb;
+      --danger: #ef4444;
+      --danger-hover: #dc2626;
+      --border: #e2e8f0;
+      --border-light: #f1f5f9;
+      --gradient-start: #f8fafc;
+      --gradient-mid: #f8fafc;
+      --gradient-end: #f8fafc;
+    }
+
     body {
       font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, sans-serif;
-      background: linear-gradient(135deg, #0b1223 0%, #0f172a 50%, #0a0f1c 100%);
+      background: linear-gradient(135deg, var(--gradient-start) 0%, var(--gradient-mid) 50%, var(--gradient-end) 100%);
       min-height: 100vh;
     }
     
@@ -89,6 +121,7 @@
         <div class="flex gap-2 flex-wrap">
           <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="exportBtn" title="Export as JSON">Export</button>
           <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="importBtn" title="Import from JSON">Import</button>
+          <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="themeBtn" title="Toggle theme">Theme</button>
           <input type="file" id="fileInput" accept="application/json" hidden />
         </div>
       </section>
@@ -99,10 +132,29 @@
     $(document).ready(function() {
       // --- Storage & State ------------------------------------------------------
       const LS_KEY = "todos.v1";
+      const THEME_KEY = "theme.v1";
       const state = {
         filter: "all",
-        todos: load()
+        todos: load(),
+        theme: localStorage.getItem(THEME_KEY) || 'dark'
       };
+
+      // --- Themeing -----------------------------------------------------------
+      function applyTheme() {
+        if (state.theme === 'light') {
+          document.documentElement.classList.add('light');
+          $('#themeBtn').text('Dark');
+        } else {
+          document.documentElement.classList.remove('light');
+          $('#themeBtn').text('Light');
+        }
+      }
+
+      function toggleTheme() {
+        state.theme = state.theme === 'light' ? 'dark' : 'light';
+        localStorage.setItem(THEME_KEY, state.theme);
+        applyTheme();
+      }
 
       // --- Utility Functions ---------------------------------------------------
       function uid() {
@@ -327,6 +379,8 @@
         }
       });
 
+      $("#themeBtn").on('click', toggleTheme);
+
       // --- Bootstrap ------------------------------------------------------------
       // Only seed initial data for first-time users (when localStorage has never been initialized)
       const hasBeenInitialized = localStorage.getItem(LS_KEY) !== null;
@@ -357,6 +411,7 @@
       
       updateStorageInfo();
       render();
+      applyTheme();
     });
   </script>
 </body>


### PR DESCRIPTION
This commit introduces a theme switcher to allow users to toggle between light and dark modes.

- Defines color palettes for both light and dark themes using CSS variables.
- Updates the Tailwind CSS configuration to use these variables, allowing for dynamic theme changes.
- Adds a 'Theme' button to the UI for toggling themes.
- Implements JavaScript logic to handle theme switching and persists the user's preference in localStorage.
- The default theme is dark.