### PR TITLE
feat: Add light and dark mode theme switcher

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,26 +12,54 @@
       theme: {
         extend: {
           colors: {
-            'bg': '#0f172a',
-            'card': '#111827',
-            'text': '#f1f5f9',
-            'muted': '#94a3b8',
-            'accent': '#3b82f6',
-            'accent-hover': '#2563eb',
-            'danger': '#ef4444',
-            'danger-hover': '#dc2626',
-            'border': '#1e293b',
-            'border-light': '#334155',
+            'bg': 'rgb(var(--color-bg-rgb) / <alpha-value>)',
+            'card': 'rgb(var(--color-card-rgb) / <alpha-value>)',
+            'text': 'rgb(var(--color-text-rgb) / <alpha-value>)',
+            'muted': 'rgb(var(--color-muted-rgb) / <alpha-value>)',
+            'accent': 'rgb(var(--color-accent-rgb) / <alpha-value>)',
+            'accent-hover': 'rgb(var(--color-accent-hover-rgb) / <alpha-value>)',
+            'danger': 'rgb(var(--color-danger-rgb) / <alpha-value>)',
+            'danger-hover': 'rgb(var(--color-danger-hover-rgb) / <alpha-value>)',
+            'border': 'rgb(var(--color-border-rgb) / <alpha-value>)',
+            'border-light': 'rgb(var(--color-border-light-rgb) / <alpha-value>)',
           }
         }
       }
     }
   </script>
   <style>
+    :root {
+      --color-bg-rgb: 248 250 252;
+      --color-card-rgb: 255 255 255;
+      --color-text-rgb: 30 41 59;
+      --color-muted-rgb: 100 116 139;
+      --color-accent-rgb: 59 130 246;
+      --color-accent-hover-rgb: 37 99 235;
+      --color-danger-rgb: 239 68 68;
+      --color-danger-hover-rgb: 220 38 38;
+      --color-border-rgb: 203 213 225;
+      --color-border-light-rgb: 226 232 240;
+      --grad-1: #e0e7ff;
+      --grad-2: #f1f5f9;
+      --grad-3: #dbeafe;
+    }
+    html.dark {
+      --color-bg-rgb: 15 23 42;
+      --color-card-rgb: 17 24 39;
+      --color-text-rgb: 241 245 249;
+      --color-muted-rgb: 148 163 184;
+      --color-border-rgb: 30 41 59;
+      --color-border-light-rgb: 51 65 85;
+      --grad-1: #0b1223;
+      --grad-2: #0f172a;
+      --grad-3: #0a0f1c;
+    }
     body {
       font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, sans-serif;
-      background: linear-gradient(135deg, #0b1223 0%, #0f172a 50%, #0a0f1c 100%);
+      background: linear-gradient(135deg, var(--grad-1) 0%, var(--grad-2) 50%, var(--grad-3) 100%);
       min-height: 100vh;
+      color: rgb(var(--color-text-rgb));
+      background-color: rgb(var(--color-bg-rgb));
     }
     
     @keyframes fadeIn {
@@ -49,15 +77,21 @@
 <body>
   <div class="max-w-2xl mx-auto my-16 px-5 md:my-16 my-5 md:px-5 px-4">
     <div class="bg-card border border-border rounded-2xl p-8 md:p-8 p-6 shadow-2xl backdrop-blur-sm animate-fade-in" role="application" aria-label="Todo app">
-      <header class="mb-8">
-        <h1 class="text-3xl font-bold mb-3 bg-gradient-to-r from-text to-muted bg-clip-text text-transparent">Toro</h1>
-        <div class="text-muted text-base leading-relaxed">Your personal task manager</div>
+      <header class="mb-8 flex justify-between items-start">
+        <div>
+          <h1 class="text-3xl font-bold mb-3 bg-gradient-to-r from-text to-muted bg-clip-text text-transparent">Toro</h1>
+          <div class="text-muted text-base leading-relaxed">Your personal task manager</div>
+        </div>
+        <button id="theme-toggle" class="p-2 rounded-full text-muted transition-colors duration-200 hover:text-accent hover:bg-accent/10" aria-label="Toggle theme">
+          <svg id="theme-toggle-dark-icon" class="hidden h-6 w-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
+          <svg id="theme-toggle-light-icon" class="hidden h-6 w-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 5.05A1 1 0 005.758 6.465l.707-.707a1 1 0 00-1.414-1.414l-.707.707zM3 11a1 1 0 100-2H2a1 1 0 100 2h1zM13 15.536l.707.707a1 1 0 01-1.414 1.414l-.707-.707a1 1 0 011.414-1.414zM4.464 13.536a1 1 0 010-1.414l.707-.707a1 1 0 011.414 1.414l-.707.707a1 1 0 01-1.414 0z"></path></svg>
+        </button>
       </header>
 
       <section class="mb-6">
         <div class="flex gap-3 items-center md:flex-row flex-col">
           <input id="newTodo" type="text" placeholder="What needs to be done?" aria-label="New todo" 
-                 class="flex-1 px-4 py-3.5 rounded-xl border border-border-light bg-slate-900/80 text-text text-base transition-all duration-200 focus:outline-none focus:border-accent focus:ring-3 focus:ring-accent/10 placeholder:text-muted w-full" />
+                 class="flex-1 px-4 py-3.5 rounded-xl border border-border-light bg-bg/80 text-text text-base transition-all duration-200 focus:outline-none focus:border-accent focus:ring-3 focus:ring-accent/10 placeholder:text-muted w-full" />
           <button id="addBtn" aria-label="Add todo" 
                   class="px-5 py-3.5 rounded-xl bg-accent text-white font-semibold text-sm cursor-pointer transition-all duration-200 hover:bg-accent-hover hover:-translate-y-0.5 whitespace-nowrap md:w-auto w-full">Add Task</button>
         </div>
@@ -81,7 +115,7 @@
           <span id="count">0</span> tasks • <span id="storage"></span>
         </div>
         <div class="text-xs opacity-80">
-          <span class="kbd px-2 py-1 border border-border-light rounded text-xs text-muted bg-slate-900/50">Enter</span> to add •
+          <span class="kbd px-2 py-1 border border-border-light rounded text-xs text-muted bg-bg/50">Enter</span> to add •
         </div>
       </footer>
 
@@ -97,6 +131,45 @@
 
   <script>
     $(document).ready(function() {
+      // --- Theme Switcher ------------------------------------------------------
+      const LS_THEME_KEY = "theme.v1";
+      const $themeToggle = $("#theme-toggle");
+      const $darkIcon = $("#theme-toggle-dark-icon");
+      const $lightIcon = $("#theme-toggle-light-icon");
+      let currentTheme = "light";
+
+      function applyTheme(theme) {
+        currentTheme = theme;
+        localStorage.setItem(LS_THEME_KEY, theme);
+
+        if (theme === 'dark') {
+          $('html').addClass('dark');
+          $darkIcon.removeClass('hidden');
+          $lightIcon.addClass('hidden');
+        } else {
+          $('html').removeClass('dark');
+          $darkIcon.addClass('hidden');
+          $lightIcon.removeClass('hidden');
+        }
+      }
+
+      $themeToggle.on('click', () => {
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        applyTheme(newTheme);
+      });
+
+      // --- Initialize Theme ----------------------------------------------------
+      const savedTheme = localStorage.getItem(LS_THEME_KEY);
+      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+      if (savedTheme) {
+        applyTheme(savedTheme);
+      } else if (systemPrefersDark) {
+        applyTheme('dark');
+      } else {
+        applyTheme('light'); // Default
+      }
+
       // --- Storage & State ------------------------------------------------------
       const LS_KEY = "todos.v1";
       const state = {
@@ -201,7 +274,7 @@
         // Inline editing
         $li.find('span').on('dblclick', function() {
           const $span = $(this);
-          const $input = $(`<input class="flex-1 px-3 py-2 rounded-lg border border-accent bg-slate-900/90 text-text text-base" value="${todo.title}">`);
+          const $input = $(`<input class="flex-1 px-3 py-2 rounded-lg border border-accent bg-card text-text text-base" value="${todo.title}">`);
           
           $span.replaceWith($input);
           $input.focus().select();


### PR DESCRIPTION
This commit introduces a theme switcher that allows users to toggle between light and dark modes.

- Defines color palettes for both light and dark themes using CSS variables.
- Updates the Tailwind CSS configuration to use these variables, enabling dynamic theme changes.
- Adds a theme toggle button to the UI with icons for light and dark modes.
- Implements JavaScript logic to handle theme switching, persisting the user's choice in localStorage.
- Initializes the theme based on the user's saved preference or their system's color scheme.