### PR TITLE
feat: Add light and dark mode theme switcher

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,28 +9,55 @@
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script>
     tailwind.config = {
+      darkMode: 'class',
       theme: {
         extend: {
           colors: {
-            'bg': '#0f172a',
-            'card': '#111827',
-            'text': '#f1f5f9',
-            'muted': '#94a3b8',
-            'accent': '#3b82f6',
-            'accent-hover': '#2563eb',
-            'danger': '#ef4444',
-            'danger-hover': '#dc2626',
-            'border': '#1e293b',
-            'border-light': '#334155',
+            'bg': 'hsl(var(--bg))',
+            'card': 'hsl(var(--card))',
+            'text': 'hsl(var(--text))',
+            'muted': 'hsl(var(--muted))',
+            'accent': 'hsl(var(--accent))',
+            'accent-hover': 'hsl(var(--accent-hover))',
+            'danger': 'hsl(var(--danger))',
+            'danger-hover': 'hsl(var(--danger-hover))',
+            'border': 'hsl(var(--border))',
+            'border-light': 'hsl(var(--border-light))',
           }
         }
       }
     }
   </script>
   <style>
+    :root {
+      --bg: 220 20% 96%;
+      --card: 220 20% 100%;
+      --text: 222 25% 15%;
+      --muted: 220 15% 45%;
+      --accent: 220 90% 60%;
+      --accent-hover: 220 90% 55%;
+      --danger: 0 85% 60%;
+      --danger-hover: 0 85% 55%;
+      --border: 220 20% 90%;
+      --border-light: 220 20% 94%;
+    }
+
+    .dark {
+      --bg: 222 25% 10%;
+      --card: 222 30% 12%;
+      --text: 220 20% 96%;
+      --muted: 220 15% 65%;
+      --accent: 220 90% 60%;
+      --accent-hover: 220 90% 65%;
+      --danger: 0 75% 55%;
+      --danger-hover: 0 75% 50%;
+      --border: 222 25% 18%;
+      --border-light: 222 25% 25%;
+    }
+
     body {
       font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, sans-serif;
-      background: linear-gradient(135deg, #0b1223 0%, #0f172a 50%, #0a0f1c 100%);
+      background-color: hsl(var(--bg));
       min-height: 100vh;
     }
     
@@ -49,15 +76,21 @@
 <body>
   <div class="max-w-2xl mx-auto my-16 px-5 md:my-16 my-5 md:px-5 px-4">
     <div class="bg-card border border-border rounded-2xl p-8 md:p-8 p-6 shadow-2xl backdrop-blur-sm animate-fade-in" role="application" aria-label="Todo app">
-      <header class="mb-8">
-        <h1 class="text-3xl font-bold mb-3 bg-gradient-to-r from-text to-muted bg-clip-text text-transparent">Toro</h1>
-        <div class="text-muted text-base leading-relaxed">Your personal task manager</div>
+      <header class="mb-8 flex justify-between items-center">
+        <div>
+          <h1 class="text-3xl font-bold mb-3 bg-gradient-to-r from-text to-muted bg-clip-text text-transparent">Toro</h1>
+          <div class="text-muted text-base leading-relaxed">Your personal task manager</div>
+        </div>
+        <button id="theme-toggle" class="p-2 rounded-full text-muted hover:text-accent hover:bg-accent/10 transition-colors">
+          <svg id="theme-icon-light" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
+          <svg id="theme-icon-dark" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+        </button>
       </header>
 
       <section class="mb-6">
         <div class="flex gap-3 items-center md:flex-row flex-col">
           <input id="newTodo" type="text" placeholder="What needs to be done?" aria-label="New todo" 
-                 class="flex-1 px-4 py-3.5 rounded-xl border border-border-light bg-slate-900/80 text-text text-base transition-all duration-200 focus:outline-none focus:border-accent focus:ring-3 focus:ring-accent/10 placeholder:text-muted w-full" />
+                 class="flex-1 px-4 py-3.5 rounded-xl border border-border-light bg-card/80 text-text text-base transition-all duration-200 focus:outline-none focus:border-accent focus:ring-3 focus:ring-accent/10 placeholder:text-muted w-full" />
           <button id="addBtn" aria-label="Add todo" 
                   class="px-5 py-3.5 rounded-xl bg-accent text-white font-semibold text-sm cursor-pointer transition-all duration-200 hover:bg-accent-hover hover:-translate-y-0.5 whitespace-nowrap md:w-auto w-full">Add Task</button>
         </div>
@@ -81,7 +114,7 @@
           <span id="count">0</span> tasks • <span id="storage"></span>
         </div>
         <div class="text-xs opacity-80">
-          <span class="kbd px-2 py-1 border border-border-light rounded text-xs text-muted bg-slate-900/50">Enter</span> to add •
+          <span class="kbd px-2 py-1 border border-border-light rounded text-xs text-muted bg-card/50">Enter</span> to add •
         </div>
       </footer>
 
@@ -326,6 +359,34 @@
           $(this).val(''); // Reset file input
         }
       });
+
+      // --- Theme ----------------------------------------------------------------
+      const THEME_KEY = "todos.theme";
+      const theme = {
+        isDark: localStorage.getItem(THEME_KEY)
+          ? localStorage.getItem(THEME_KEY) === 'dark'
+          : window.matchMedia('(prefers-color-scheme: dark)').matches,
+      };
+
+      function applyTheme() {
+        if (theme.isDark) {
+          document.documentElement.classList.add('dark');
+          $('#theme-icon-dark').show();
+          $('#theme-icon-light').hide();
+        } else {
+          document.documentElement.classList.remove('dark');
+          $('#theme-icon-dark').hide();
+          $('#theme-icon-light').show();
+        }
+      }
+
+      $('#theme-toggle').on('click', function() {
+        theme.isDark = !theme.isDark;
+        localStorage.setItem(THEME_KEY, theme.isDark ? "dark" : "light");
+        applyTheme();
+      });
+
+      applyTheme();
 
       // --- Bootstrap ------------------------------------------------------------
       // Only seed initial data for first-time users (when localStorage has never been initialized)


### PR DESCRIPTION
This commit introduces a theme switcher that allows users to toggle between light and dark modes.

The implementation includes:
- A theme toggle button in the header with sun and moon icons.
- CSS custom properties (variables) for defining color palettes for both light and dark themes.
- Updated Tailwind CSS configuration to use the new theme variables and enable class-based dark mode.
- JavaScript logic to handle theme switching, persist the user's choice in `localStorage`, and respect the `prefers-color-scheme` media query for the initial theme.