### PR TITLE
feat: Add light and dark mode theme switcher

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,25 +12,51 @@
       theme: {
         extend: {
           colors: {
-            'bg': '#0f172a',
-            'card': '#111827',
-            'text': '#f1f5f9',
-            'muted': '#94a3b8',
-            'accent': '#3b82f6',
-            'accent-hover': '#2563eb',
-            'danger': '#ef4444',
-            'danger-hover': '#dc2626',
-            'border': '#1e293b',
-            'border-light': '#334155',
+            'bg': 'var(--bg)',
+            'card': 'var(--card)',
+            'text': 'var(--text)',
+            'muted': 'var(--muted)',
+            'accent': 'var(--accent)',
+            'accent-hover': 'var(--accent-hover)',
+            'danger': 'var(--danger)',
+            'danger-hover': 'var(--danger-hover)',
+            'border': 'var(--border)',
+            'border-light': 'var(--border-light)',
           }
         }
       }
     }
   </script>
   <style>
+    :root {
+      --bg: #f1f5f9;
+      --card: #ffffff;
+      --text: #0f172a;
+      --muted: #64748b;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --danger: #dc2626;
+      --danger-hover: #b91c1c;
+      --border: #e2e8f0;
+      --border-light: #cbd5e1;
+    }
+
+    .dark {
+      --bg: #0f172a;
+      --card: #111827;
+      --text: #f1f5f9;
+      --muted: #94a3b8;
+      --accent: #3b82f6;
+      --accent-hover: #2563eb;
+      --danger: #ef4444;
+      --danger-hover: #dc2626;
+      --border: #1e293b;
+      --border-light: #334155;
+    }
+
     body {
       font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, sans-serif;
-      background: linear-gradient(135deg, #0b1223 0%, #0f172a 50%, #0a0f1c 100%);
+      background: linear-gradient(135deg, var(--bg) 0%, var(--card) 50%, var(--bg) 100%);
       min-height: 100vh;
     }
     
@@ -42,11 +68,10 @@
     .animate-fade-in {
       animation: fadeIn 0.6s ease-out;
     }
-
   </style>
 </head>
 
-<body>
+<body class="dark">
   <div class="max-w-2xl mx-auto my-16 px-5 md:my-16 my-5 md:px-5 px-4">
     <div class="bg-card border border-border rounded-2xl p-8 md:p-8 p-6 shadow-2xl backdrop-blur-sm animate-fade-in" role="application" aria-label="Todo app">
       <header class="mb-8">
@@ -89,6 +114,7 @@
         <div class="flex gap-2 flex-wrap">
           <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="exportBtn" title="Export as JSON">Export</button>
           <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="importBtn" title="Import from JSON">Import</button>
+          <button class="ghost px-4 py-2 rounded-xl bg-transparent text-muted border border-border-light cursor-pointer transition-all duration-200 hover:bg-accent/10 hover:text-accent hover:border-accent" id="themeBtn" title="Toggle theme">Theme</button>
           <input type="file" id="fileInput" accept="application/json" hidden />
         </div>
       </section>
@@ -97,14 +123,26 @@
 
   <script>
     $(document).ready(function() {
+      // --- Themes ---------------------------------------------------------------
+      const THEME_KEY = "theme.v1";
+
       // --- Storage & State ------------------------------------------------------
       const LS_KEY = "todos.v1";
       const state = {
         filter: "all",
-        todos: load()
+        todos: load(),
+        theme: localStorage.getItem(THEME_KEY) || 'dark'
       };
 
       // --- Utility Functions ---------------------------------------------------
+      function applyTheme(theme) {
+        if (theme === 'dark') {
+          $('body').addClass('dark');
+        } else {
+          $('body').removeClass('dark');
+        }
+      }
+
       function uid() {
         return Math.random().toString(36).slice(2) + Date.now().toString(36);
       }
@@ -327,6 +365,12 @@
         }
       });
 
+      $('#themeBtn').on('click', function() {
+        state.theme = state.theme === 'dark' ? 'light' : 'dark';
+        localStorage.setItem(THEME_KEY, state.theme);
+        applyTheme(state.theme);
+      });
+
       // --- Bootstrap ------------------------------------------------------------
       // Only seed initial data for first-time users (when localStorage has never been initialized)
       const hasBeenInitialized = localStorage.getItem(LS_KEY) !== null;
@@ -356,6 +400,7 @@
       }
       
       updateStorageInfo();
+      applyTheme(state.theme);
       render();
     });
   </script>


### PR DESCRIPTION
This commit introduces a theme switcher to allow users to toggle between a light and dark mode.

- A "Theme" button has been added to the UI.
- The color scheme has been refactored to use CSS variables for easy theme switching.
- The user's theme preference is saved in `localStorage` and applied on page load.
- The default theme is dark.